### PR TITLE
Document storage and resource lifecycles

### DIFF
--- a/common/src/main/java/io/github/solusmods/eternalcore/api/qi_energy/AbstractQiEnergy.java
+++ b/common/src/main/java/io/github/solusmods/eternalcore/api/qi_energy/AbstractQiEnergy.java
@@ -5,30 +5,55 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
- * Абстрактний базовий клас для всіх елементів у модифікації EternalCore.
+ * Базова модель енергії Ці.
  * <p>
- * Елементи є основними компонентами системи, які можуть бути додані до живих сутностей.
- * Кожен елемент має свій тип і може мати протилежний елемент. Елементи реєструються
- * у реєстрі ElementAPI і мають унікальні ідентифікатори.
+ * Реалізації обов'язково реєструються у {@link QiEnergyAPI#getElementRegistry()} перед використанням.
+ * Кожна енергія повинна надавати стабільний ідентифікатор через {@link #getElement()} та підтримувати
+ * серіалізацію у відповідному класі-реалізації (див. {@link ElementalQiEnergy}). Значення {@link #amount}
+ * синхронізується через сховище {@link io.github.solusmods.eternalcore.impl.qi_energy.QiEnergyStorage}.
+ * </p>
  */
 @ToString
 public abstract class AbstractQiEnergy {
 
     @Getter
     @Setter
+    /**
+     * Поточна кількість енергії Ці.
+     */
     protected double amount;
 
 
+    /**
+     * Створює енергію із заданою кількістю.
+     *
+     * @param amount Початковий обсяг
+     */
     protected AbstractQiEnergy(double amount) {
         this.amount = amount;
     }
 
+    /**
+     * Повертає тип енергії, зареєстрований у реєстрі.
+     *
+     * @return {@link ElementType} енергії
+     */
     public abstract ElementType getElement();
 
+    /**
+     * Збільшує кількість енергії.
+     *
+     * @param amount Кількість для додавання (може бути від'ємною для корекції)
+     */
     public void add(double amount) {
         this.amount += amount;
     }
 
+    /**
+     * Зменшує кількість енергії, не дозволяючи значенню стати від'ємним.
+     *
+     * @param amount Кількість для віднімання
+     */
     public void subtract(double amount) {
         this.amount = Math.max(0, this.amount - amount);
     }


### PR DESCRIPTION
## Summary
- add detailed lifecycle, registration, and serialization documentation to AbstractStage, AbstractRealm, AbstractQiEnergy, and AbstractSpiritualRoot
- document public APIs of QiEnergyStorage, SpiritualRootStorage, StageStorage, and RealmStorage including event interactions and sync contracts
- expose explicit storage accessors with consistent JavaDoc style for generated getters

## Testing
- ./gradlew javadoc

------
https://chatgpt.com/codex/tasks/task_e_68e4d9049e58832081001987fc8759a0