### PR TITLE
Prevent duplicate storage registration

### DIFF
--- a/common/src/main/java/io/github/solusmods/eternalcore/impl/storage/StorageRegistryImpl.java
+++ b/common/src/main/java/io/github/solusmods/eternalcore/impl/storage/StorageRegistryImpl.java
@@ -38,6 +38,9 @@ public class StorageRegistryImpl<T extends StorageHolder> implements StorageEven
      */
     @Override
     public <S extends AbstractStorage> StorageKey<S> register(ResourceLocation id, Class<S> storageClass, Predicate<T> attachCheck, StorageEvents.StorageFactory<T, S> factory) {
+        if (this.registry.containsKey(id)) {
+            throw new IllegalStateException("Storage with id " + id + " is already registered");
+        }
         this.registry.put(id, Pair.of(attachCheck, factory));
         return new StorageKey<>(id, storageClass);
     }


### PR DESCRIPTION
## Summary
- guard storage registration against duplicate identifiers by checking the registry before insertion
- throw an IllegalStateException when attempting to register a storage id that is already present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e62bb4cc508320aa61985c99c35083